### PR TITLE
Reference implementation: InitialisePromise, fixes #109

### DIFF
--- a/reference-implementation/lib/testable-implementation.js
+++ b/reference-implementation/lib/testable-implementation.js
@@ -293,7 +293,7 @@ function InitialisePromise(promise, executor) {
     try {
         executor.call(undefined, resolvingFunctions["[[Resolve]]"], resolvingFunctions["[[Reject]]"]);
     } catch (completionE) {
-        reject.call(undefined, completionE);
+        resolvingFunctions["[[Reject]]"].call(undefined, completionE);
     }
 
     return promise;

--- a/reference-implementation/test/simple.js
+++ b/reference-implementation/test/simple.js
@@ -34,6 +34,25 @@ describe("Self-resolution errors", function () {
     });
 });
 
+specify("An abrupt completion of the executor function should result in a rejected promise", function () {
+    var promise;
+
+    assert.doesNotThrow(function () {
+        promise = OrdinaryConstruct(Promise, [function () { throw new Error(); }]);
+    });
+
+    promise.then(
+        function () {
+            assert(false, "Should not be fulfilled");
+            done();
+        },
+        function (err) {
+            assert(err instanceof Error);
+            done();
+        }
+    );
+});
+
 specify("Stealing a resolver and using it to trigger possible reentrancy bug (#83)", function () {
     var stolenResolver;
     function StealingPromiseConstructor(resolver) {


### PR DESCRIPTION
Fixes #109:

> It seems that the [line after the catch()](https://github.com/domenic/promises-unwrapping/blob/7e434e4b/reference-implementation/lib/testable-implementation.js#L296) is supposed to call `resolvingFunctions["[[Reject]]"]` rather than `reject`.
> 
>  I also noticed that this specific part of the spec (draft) is not tested in the reference implementation's tests.
